### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -53,7 +53,7 @@
 #'
 #' Cochran WG. 1936. The statistical analysis of field counts of
 #'     diseased plants. Supplement to the Journal of the Royal Statistical
-#'     Society 3, 49–67. \href{http://dx.doi.org/10.2307/2983677}{doi:10.2307/2983677}
+#'     Society 3, 49–67. \href{https://doi.org/10.2307/2983677}{doi:10.2307/2983677}
 #'
 #' Bald JG. 1937. Investigations on "spotted wilt" of tomatoes. III.
 #'     Infection in field plots. Bulletin 106. Melbourne, Australia: Council for
@@ -100,7 +100,7 @@
 #'
 #' Gibson GJ. 1997. Investigating mechanisms of spatiotemporal epidemic
 #'     spread using stochastic models. Phytopathology 87, 139-46.
-#'     \href{http://dx.doi.org/10.1094/PHYTO.1997.87.2.139}{doi:10.1094/PHYTO.1997.87.2.139}
+#'     \href{https://doi.org/10.1094/PHYTO.1997.87.2.139}{doi:10.1094/PHYTO.1997.87.2.139}
 #------------------------------------------------------------------------------#
 "citrus_ctv"
 
@@ -133,7 +133,7 @@
 #' Pethybridge SJ, Madden LV. 2003. Analysis of spatiotemporal dynamics
 #'     of virus spread in an Australian hop garden by stochastic modeling. Plant
 #'     Disease 87:56-62.
-#'     \href{http://dx.doi.org/10.1094/PDIS.2003.87.1.56}{doi:10.1094/PDIS.2003.87.1.56}
+#'     \href{https://doi.org/10.1094/PDIS.2003.87.1.56}{doi:10.1094/PDIS.2003.87.1.56}
 #------------------------------------------------------------------------------#
 "hop_viruses"
 
@@ -160,7 +160,7 @@
 #' Roumagnac P, Pruvost O, Chiroleu F, Hughes G. 2004. Spatial and
 #'     temporal analyses of bacterial blight of onion caused by Xanthomonas
 #'     axonopodis pv. allii. Phytopathology 94, 138–146.
-#'     \href{http://dx.doi.org/10.1094/PHYTO.2004.94.2.138}{doi:10.1094/PHYTO.2004.94.2.138}
+#'     \href{https://doi.org/10.1094/PHYTO.2004.94.2.138}{doi:10.1094/PHYTO.2004.94.2.138}
 #------------------------------------------------------------------------------#
 "onion_bacterial_blight"
 
@@ -188,7 +188,7 @@
 #'
 #' Xu XM, Madden LV. 2004. Use of SADIE statistics to study spatial
 #'   dynamics of plant disease epidemics. Plant Pathology 53, 38–49.
-#'   \href{http://dx.doi.org/10.1111/j.1365-3059.2004.00949.x}{doi:10.1111/j.1365-3059.2004.00949.x}
+#'   \href{https://doi.org/10.1111/j.1365-3059.2004.00949.x}{doi:10.1111/j.1365-3059.2004.00949.x}
 #------------------------------------------------------------------------------#
 "simulated_epidemics"
 
@@ -254,7 +254,7 @@
 #' Pethybridge SJ, Esker P, Hay F, Wilson C, Nutter FW. 2005.
 #'     Spatiotemporal description of epidemics caused by Phoma ligulicola in
 #'     Tasmanian pyrethrum fields. \emph{Phytopathology} 95, 648–658.
-#'     \href{http://dx.doi.org/10.1094/PHYTO-95-0648}{doi:10.1094/PHYTO-95-0648}
+#'     \href{https://doi.org/10.1094/PHYTO-95-0648}{doi:10.1094/PHYTO-95-0648}
 #------------------------------------------------------------------------------#
 "pyrethrum_ray_blight"
 
@@ -277,7 +277,7 @@
 #'
 #' Perry JN, Winder L, Holland JM, Alston RD. 1999. Red-blue plots for
 #'     detecting clusters in count data. Ecology Letters 2, 106-13.
-#'     \href{http://dx.doi.org/10.1046/j.1461-0248.1999.22057.x}{doi:10.1046/j.1461-0248.1999.22057.x}
+#'     \href{https://doi.org/10.1046/j.1461-0248.1999.22057.x}{doi:10.1046/j.1461-0248.1999.22057.x}
 #------------------------------------------------------------------------------#
 "aphids"
 
@@ -324,7 +324,7 @@
 #' Lavigne C, Ricci B, Franck P, Senoussi R. 2010. Spatial analyses of
 #'     ecological count data: A density map comparison approach. Basic and
 #'     Applied Ecology 11: 734-42.
-#'     \href{http://dx.doi.org/10.1016/j.baae.2010.08.011}{doi:10.1016/j.baae.2010.08.011}
+#'     \href{https://doi.org/10.1016/j.baae.2010.08.011}{doi:10.1016/j.baae.2010.08.011}
 #------------------------------------------------------------------------------#
 "codling_moths"
 

--- a/R/distr-fitting.R
+++ b/R/distr-fitting.R
@@ -98,7 +98,7 @@ NULL
 #' Madden LV, Hughes G. 1995. Plant disease incidence: Distributions,
 #' heterogeneity, and temporal analysis. Annual Review of Phytopathology 33(1):
 #' 529–564.
-#' \href{http://dx.doi.org/doi:10.1146/annurev.py.33.090195.002525}{doi:10.1146/annurev.py.33.090195.002525}
+#' \href{https://doi.org/doi:10.1146/annurev.py.33.090195.002525}{doi:10.1146/annurev.py.33.090195.002525}
 #'
 #' @export
 #------------------------------------------------------------------------------#

--- a/R/indices.R
+++ b/R/indices.R
@@ -96,12 +96,12 @@ NULL
 #'
 #' Morisita M. 1962. I\eqn{\delta}-Index, a measure of dispersion of
 #' individuals. Researches on Population Ecology 4, 1–7.
-#' \href{http://dx.doi.org/doi:10.1007/BF02533903}{doi:10.1007/BF02533903}
+#' \href{https://doi.org/doi:10.1007/BF02533903}{doi:10.1007/BF02533903}
 #'
 #' Madden LV, Hughes G. 1995. Plant disease incidence: Distributions,
 #' heterogeneity, and temporal analysis. Annual Review of Phytopathology 33(1):
 #' 529–564.
-#' \href{http://dx.doi.org/doi:10.1146/annurev.py.33.090195.002525}{doi:10.1146/annurev.py.33.090195.002525}
+#' \href{https://doi.org/doi:10.1146/annurev.py.33.090195.002525}{doi:10.1146/annurev.py.33.090195.002525}
 #'
 #' @export
 #------------------------------------------------------------------------------#
@@ -318,7 +318,7 @@ morisita.incidence <- function(x, ...) {
 #' Madden LV, Hughes G. 1995. Plant disease incidence: Distributions,
 #' heterogeneity, and temporal analysis. Annual Review of Phytopathology 33(1):
 #' 529–564.
-#' \href{http://dx.doi.org/doi:10.1146/annurev.py.33.090195.002525}{doi:10.1146/annurev.py.33.090195.002525}
+#' \href{https://doi.org/doi:10.1146/annurev.py.33.090195.002525}{doi:10.1146/annurev.py.33.090195.002525}
 #'
 #' Patil GP, Stiteler WM. 1973. Concepts of aggregation and their
 #' quantification: a critical review with some new results and applications.

--- a/R/power-law.R
+++ b/R/power-law.R
@@ -49,7 +49,7 @@ NULL
 #'
 #' Hughes G, Madden LV. 1992. Aggregation and incidence of disease. Plant
 #' Pathology 41 (6): 657–660.
-#' \href{http://dx.doi.org/10.1111/j.1365-3059.1992.tb02549.x}{doi:10.1111/j.1365-3059.1992.tb02549.x}
+#' \href{https://doi.org/10.1111/j.1365-3059.1992.tb02549.x}{doi:10.1111/j.1365-3059.1992.tb02549.x}
 #'
 #' Madden LV, Hughes G, van den Bosch F. 2007. Spatial aspects of epidemics -
 #' III: Patterns of plant disease. In: The study of plant disease epidemics,

--- a/R/sadie.R
+++ b/R/sadie.R
@@ -28,16 +28,16 @@
 #' @references
 #'
 #' Perry JN. 1995. Spatial analysis by distance indices. Journal of Animal
-#' Ecology 64, 303–314. \href{http://dx.doi.org/10.2307/5892}{doi:10.2307/5892}
+#' Ecology 64, 303–314. \href{https://doi.org/10.2307/5892}{doi:10.2307/5892}
 #'
 #' Perry JN, Winder L, Holland JM, Alston RD. 1999. Red–blue plots for detecting
 #' clusters in count data. Ecology Letters 2, 106–113.
-#' \href{http://dx.doi.org/10.1046/j.1461-0248.1999.22057.x}{doi:10.1046/j.1461-0248.1999.22057.x}
+#' \href{https://doi.org/10.1046/j.1461-0248.1999.22057.x}{doi:10.1046/j.1461-0248.1999.22057.x}
 #'
 #' Li B, Madden LV, Xu X. 2012. Spatial analysis by distance indices: an
 #' alternative local clustering index for studying spatial patterns. Methods in
 #' Ecology and Evolution 3, 368–377.
-#' \href{http://dx.doi.org/10.1111/j.2041-210X.2011.00165.x}{doi:10.1111/j.2041-210X.2011.00165.x}
+#' \href{https://doi.org/10.1111/j.2041-210X.2011.00165.x}{doi:10.1111/j.2041-210X.2011.00165.x}
 #'
 #' @examples
 #' set.seed(123)

--- a/docs/reference/agg_index.html
+++ b/docs/reference/agg_index.html
@@ -194,11 +194,11 @@ Edinburgh.</p>
 <p>Lloyd M. 1967. Mean crowding. The Journal of Animal Ecology 36, 1–30.</p>
 <p>Morisita M. 1962. I\(\delta\)-Index, a measure of dispersion of
 individuals. Researches on Population Ecology 4, 1–7.
-<a href='http://dx.doi.org/doi:10.1007/BF02533903'>doi:10.1007/BF02533903</a></p>
+<a href='https://doi.org/doi:10.1007/BF02533903'>doi:10.1007/BF02533903</a></p>
 <p>Madden LV, Hughes G. 1995. Plant disease incidence: Distributions,
 heterogeneity, and temporal analysis. Annual Review of Phytopathology 33(1):
 529–564.
-<a href='http://dx.doi.org/doi:10.1146/annurev.py.33.090195.002525'>doi:10.1146/annurev.py.33.090195.002525</a></p>
+<a href='https://doi.org/doi:10.1146/annurev.py.33.090195.002525'>doi:10.1146/annurev.py.33.090195.002525</a></p>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
 

--- a/docs/reference/aphids.html
+++ b/docs/reference/aphids.html
@@ -139,7 +139,7 @@ a 9 x 7 rectangular grid at intervals of 30 m.</p>
 
     <p>Perry JN, Winder L, Holland JM, Alston RD. 1999. Red-blue plots for
     detecting clusters in count data. Ecology Letters 2, 106-13.
-    <a href='http://dx.doi.org/10.1046/j.1461-0248.1999.22057.x'>doi:10.1046/j.1461-0248.1999.22057.x</a></p>
+    <a href='https://doi.org/10.1046/j.1461-0248.1999.22057.x'>doi:10.1046/j.1461-0248.1999.22057.x</a></p>
     
 
   </div>

--- a/docs/reference/chisq.test.html
+++ b/docs/reference/chisq.test.html
@@ -159,7 +159,7 @@ with N - 1 degrees of freedom. N is the number of sampling units.</p>
 <p>Madden LV, Hughes G. 1995. Plant disease incidence: Distributions,
 heterogeneity, and temporal analysis. Annual Review of Phytopathology 33(1):
 529–564.
-<a href='http://dx.doi.org/doi:10.1146/annurev.py.33.090195.002525'>doi:10.1146/annurev.py.33.090195.002525</a></p>
+<a href='https://doi.org/doi:10.1146/annurev.py.33.090195.002525'>doi:10.1146/annurev.py.33.090195.002525</a></p>
 <p>Patil GP, Stiteler WM. 1973. Concepts of aggregation and their
 quantification: a critical review with some new results and applications.
 Researches on Population Ecology, 15(1): 238-254.</p>

--- a/docs/reference/citrus_ctv.html
+++ b/docs/reference/citrus_ctv.html
@@ -146,7 +146,7 @@ consecutive years.</p>
     Phytopathology 86, 45–55.</p>
 <p>Gibson GJ. 1997. Investigating mechanisms of spatiotemporal epidemic
     spread using stochastic models. Phytopathology 87, 139-46.
-    <a href='http://dx.doi.org/10.1094/PHYTO.1997.87.2.139'>doi:10.1094/PHYTO.1997.87.2.139</a></p>
+    <a href='https://doi.org/10.1094/PHYTO.1997.87.2.139'>doi:10.1094/PHYTO.1997.87.2.139</a></p>
     
     <h2 class="hasAnchor" id="details"><a class="anchor" href="#details"></a>Details</h2>
 

--- a/docs/reference/codling_moths.html
+++ b/docs/reference/codling_moths.html
@@ -137,7 +137,7 @@ trunks in July 2008 and collected the following October. 30 traps were used.</p>
     <p>Lavigne C, Ricci B, Franck P, Senoussi R. 2010. Spatial analyses of
     ecological count data: A density map comparison approach. Basic and
     Applied Ecology 11: 734-42.
-    <a href='http://dx.doi.org/10.1016/j.baae.2010.08.011'>doi:10.1016/j.baae.2010.08.011</a></p>
+    <a href='https://doi.org/10.1016/j.baae.2010.08.011'>doi:10.1016/j.baae.2010.08.011</a></p>
     
 
   </div>

--- a/docs/reference/fit_two_distr.html
+++ b/docs/reference/fit_two_distr.html
@@ -205,7 +205,7 @@ if any expected count is less than 5 (Cochran's rule of thumb).</p>
     <p>Madden LV, Hughes G. 1995. Plant disease incidence: Distributions,
 heterogeneity, and temporal analysis. Annual Review of Phytopathology 33(1):
 529–564.
-<a href='http://dx.doi.org/doi:10.1146/annurev.py.33.090195.002525'>doi:10.1146/annurev.py.33.090195.002525</a></p>
+<a href='https://doi.org/doi:10.1146/annurev.py.33.090195.002525'>doi:10.1146/annurev.py.33.090195.002525</a></p>
     
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>

--- a/docs/reference/hop_viruses.html
+++ b/docs/reference/hop_viruses.html
@@ -150,7 +150,7 @@ between plants within rows.</p>
     <p>Pethybridge SJ, Madden LV. 2003. Analysis of spatiotemporal dynamics
     of virus spread in an Australian hop garden by stochastic modeling. Plant
     Disease 87:56-62.
-    <a href='http://dx.doi.org/10.1094/PDIS.2003.87.1.56'>doi:10.1094/PDIS.2003.87.1.56</a></p>
+    <a href='https://doi.org/10.1094/PDIS.2003.87.1.56'>doi:10.1094/PDIS.2003.87.1.56</a></p>
     
 
   </div>

--- a/docs/reference/iwao.html
+++ b/docs/reference/iwao.html
@@ -134,7 +134,7 @@
 
     <p>Iwao S. 1968. A new regression method for analyzing the aggregation pattern
 of animal populations. Researches on Population Ecology 10, 1–20.
-<a href='http://dx.doi.org/10.1007/BF02514729'>doi:10.1007/BF02514729</a></p>
+<a href='https://doi.org/10.1007/BF02514729'>doi:10.1007/BF02514729</a></p>
     
 
   </div>

--- a/docs/reference/onion_bacterial_blight.html
+++ b/docs/reference/onion_bacterial_blight.html
@@ -140,7 +140,7 @@ L. cv. Chateau-vieux) seed lot, with a contamination rate of about 0.04%.</p>
     <p>Roumagnac P, Pruvost O, Chiroleu F, Hughes G. 2004. Spatial and
     temporal analyses of bacterial blight of onion caused by Xanthomonas
     axonopodis pv. allii. Phytopathology 94, 138–146.
-    <a href='http://dx.doi.org/10.1094/PHYTO.2004.94.2.138'>doi:10.1094/PHYTO.2004.94.2.138</a></p>
+    <a href='https://doi.org/10.1094/PHYTO.2004.94.2.138'>doi:10.1094/PHYTO.2004.94.2.138</a></p>
     
 
   </div>

--- a/docs/reference/power_law.html
+++ b/docs/reference/power_law.html
@@ -161,7 +161,7 @@ of incidence data, and the absolute value in case of count data.</p>
     <p>Taylor LR. 1961. Aggregation, variance and the mean. Nature 189: 732–35.</p>
 <p>Hughes G, Madden LV. 1992. Aggregation and incidence of disease. Plant
 Pathology 41 (6): 657–660.
-<a href='http://dx.doi.org/10.1111/j.1365-3059.1992.tb02549.x'>doi:10.1111/j.1365-3059.1992.tb02549.x</a></p>
+<a href='https://doi.org/10.1111/j.1365-3059.1992.tb02549.x'>doi:10.1111/j.1365-3059.1992.tb02549.x</a></p>
 <p>Madden LV, Hughes G, van den Bosch F. 2007. Spatial aspects of epidemics -
 III: Patterns of plant disease. In: The study of plant disease epidemics,
 235–278. American Phytopathological Society, St Paul, MN.</p>

--- a/docs/reference/pyrethrum_ray_blight.html
+++ b/docs/reference/pyrethrum_ray_blight.html
@@ -136,7 +136,7 @@ sampling units, containing 6 plants each.</p>
     <p>Pethybridge SJ, Esker P, Hay F, Wilson C, Nutter FW. 2005.
     Spatiotemporal description of epidemics caused by Phoma ligulicola in
     Tasmanian pyrethrum fields. <em>Phytopathology</em> 95, 648–658.
-    <a href='http://dx.doi.org/10.1094/PHYTO-95-0648'>doi:10.1094/PHYTO-95-0648</a></p>
+    <a href='https://doi.org/10.1094/PHYTO-95-0648'>doi:10.1094/PHYTO-95-0648</a></p>
     
 
   </div>

--- a/docs/reference/sadie.html
+++ b/docs/reference/sadie.html
@@ -200,14 +200,14 @@ respectively.</p>
     <h2 class="hasAnchor" id="references"><a class="anchor" href="#references"></a>References</h2>
 
     <p>Perry JN. 1995. Spatial analysis by distance indices. Journal of Animal
-Ecology 64, 303–314. <a href='http://dx.doi.org/10.2307/5892'>doi:10.2307/5892</a></p>
+Ecology 64, 303–314. <a href='https://doi.org/10.2307/5892'>doi:10.2307/5892</a></p>
 <p>Perry JN, Winder L, Holland JM, Alston RD. 1999. Red–blue plots for detecting
 clusters in count data. Ecology Letters 2, 106–113.
-<a href='http://dx.doi.org/10.1046/j.1461-0248.1999.22057.x'>doi:10.1046/j.1461-0248.1999.22057.x</a></p>
+<a href='https://doi.org/10.1046/j.1461-0248.1999.22057.x'>doi:10.1046/j.1461-0248.1999.22057.x</a></p>
 <p>Li B, Madden LV, Xu X. 2012. Spatial analysis by distance indices: an
 alternative local clustering index for studying spatial patterns. Methods in
 Ecology and Evolution 3, 368–377.
-<a href='http://dx.doi.org/10.1111/j.2041-210X.2011.00165.x'>doi:10.1111/j.2041-210X.2011.00165.x</a></p>
+<a href='https://doi.org/10.1111/j.2041-210X.2011.00165.x'>doi:10.1111/j.2041-210X.2011.00165.x</a></p>
     
 
     <h2 class="hasAnchor" id="examples"><a class="anchor" href="#examples"></a>Examples</h2>

--- a/docs/reference/simulated_epidemics.html
+++ b/docs/reference/simulated_epidemics.html
@@ -145,7 +145,7 @@ sampling units, and different values for the parameters <code>pattern</code> and
 
     <p>Xu XM, Madden LV. 2004. Use of SADIE statistics to study spatial
   dynamics of plant disease epidemics. Plant Pathology 53, 38–49.
-  <a href='http://dx.doi.org/10.1111/j.1365-3059.2004.00949.x'>doi:10.1111/j.1365-3059.2004.00949.x</a></p>
+  <a href='https://doi.org/10.1111/j.1365-3059.2004.00949.x'>doi:10.1111/j.1365-3059.2004.00949.x</a></p>
     
 
   </div>

--- a/docs/reference/tomato_tswv.html
+++ b/docs/reference/tomato_tswv.html
@@ -155,7 +155,7 @@ thrips.</p>
 
     <p>Cochran WG. 1936. The statistical analysis of field counts of
     diseased plants. Supplement to the Journal of the Royal Statistical
-    Society 3, 49–67. <a href='http://dx.doi.org/10.2307/2983677'>doi:10.2307/2983677</a></p>
+    Society 3, 49–67. <a href='https://doi.org/10.2307/2983677'>doi:10.2307/2983677</a></p>
 <p>Bald JG. 1937. Investigations on "spotted wilt" of tomatoes. III.
     Infection in field plots. Bulletin 106. Melbourne, Australia: Council for
     Scientific and Industrial Research.</p>

--- a/man/agg_index.Rd
+++ b/man/agg_index.Rd
@@ -98,12 +98,12 @@ Lloyd M. 1967. Mean crowding. The Journal of Animal Ecology 36, 1–30.
 
 Morisita M. 1962. I\eqn{\delta}-Index, a measure of dispersion of
 individuals. Researches on Population Ecology 4, 1–7.
-\href{http://dx.doi.org/doi:10.1007/BF02533903}{doi:10.1007/BF02533903}
+\href{https://doi.org/doi:10.1007/BF02533903}{doi:10.1007/BF02533903}
 
 Madden LV, Hughes G. 1995. Plant disease incidence: Distributions,
 heterogeneity, and temporal analysis. Annual Review of Phytopathology 33(1):
 529–564.
-\href{http://dx.doi.org/doi:10.1146/annurev.py.33.090195.002525}{doi:10.1146/annurev.py.33.090195.002525}
+\href{https://doi.org/doi:10.1146/annurev.py.33.090195.002525}{doi:10.1146/annurev.py.33.090195.002525}
 }
 \seealso{
 \code{\link[vegan]{vegdist}} in \strong{vegan} package.

--- a/man/aphids.Rd
+++ b/man/aphids.Rd
@@ -13,7 +13,7 @@
 \source{
 Perry JN, Winder L, Holland JM, Alston RD. 1999. Red-blue plots for
     detecting clusters in count data. Ecology Letters 2, 106-13.
-    \href{http://dx.doi.org/10.1046/j.1461-0248.1999.22057.x}{doi:10.1046/j.1461-0248.1999.22057.x}
+    \href{https://doi.org/10.1046/j.1461-0248.1999.22057.x}{doi:10.1046/j.1461-0248.1999.22057.x}
 }
 \usage{
 aphids

--- a/man/chisq.test.Rd
+++ b/man/chisq.test.Rd
@@ -43,7 +43,7 @@ For count and incidence data:
 Madden LV, Hughes G. 1995. Plant disease incidence: Distributions,
 heterogeneity, and temporal analysis. Annual Review of Phytopathology 33(1):
 529–564.
-\href{http://dx.doi.org/doi:10.1146/annurev.py.33.090195.002525}{doi:10.1146/annurev.py.33.090195.002525}
+\href{https://doi.org/doi:10.1146/annurev.py.33.090195.002525}{doi:10.1146/annurev.py.33.090195.002525}
 
 Patil GP, Stiteler WM. 1973. Concepts of aggregation and their
 quantification: a critical review with some new results and applications.

--- a/man/citrus_ctv.Rd
+++ b/man/citrus_ctv.Rd
@@ -27,7 +27,7 @@ Gottwald TR, Cambra M, Moreno P, Camarasa E, Piquer J. 1996. Spatial
 
 Gibson GJ. 1997. Investigating mechanisms of spatiotemporal epidemic
     spread using stochastic models. Phytopathology 87, 139-46.
-    \href{http://dx.doi.org/10.1094/PHYTO.1997.87.2.139}{doi:10.1094/PHYTO.1997.87.2.139}
+    \href{https://doi.org/10.1094/PHYTO.1997.87.2.139}{doi:10.1094/PHYTO.1997.87.2.139}
 }
 \usage{
 citrus_ctv

--- a/man/codling_moths.Rd
+++ b/man/codling_moths.Rd
@@ -13,7 +13,7 @@
 Lavigne C, Ricci B, Franck P, Senoussi R. 2010. Spatial analyses of
     ecological count data: A density map comparison approach. Basic and
     Applied Ecology 11: 734-42.
-    \href{http://dx.doi.org/10.1016/j.baae.2010.08.011}{doi:10.1016/j.baae.2010.08.011}
+    \href{https://doi.org/10.1016/j.baae.2010.08.011}{doi:10.1016/j.baae.2010.08.011}
 }
 \usage{
 codling_moths

--- a/man/fit_two_distr.Rd
+++ b/man/fit_two_distr.Rd
@@ -112,5 +112,5 @@ lapply(my_agg_index, chisq.test)
 Madden LV, Hughes G. 1995. Plant disease incidence: Distributions,
 heterogeneity, and temporal analysis. Annual Review of Phytopathology 33(1):
 529–564.
-\href{http://dx.doi.org/doi:10.1146/annurev.py.33.090195.002525}{doi:10.1146/annurev.py.33.090195.002525}
+\href{https://doi.org/doi:10.1146/annurev.py.33.090195.002525}{doi:10.1146/annurev.py.33.090195.002525}
 }

--- a/man/hop_viruses.Rd
+++ b/man/hop_viruses.Rd
@@ -18,7 +18,7 @@
 Pethybridge SJ, Madden LV. 2003. Analysis of spatiotemporal dynamics
     of virus spread in an Australian hop garden by stochastic modeling. Plant
     Disease 87:56-62.
-    \href{http://dx.doi.org/10.1094/PDIS.2003.87.1.56}{doi:10.1094/PDIS.2003.87.1.56}
+    \href{https://doi.org/10.1094/PDIS.2003.87.1.56}{doi:10.1094/PDIS.2003.87.1.56}
 }
 \usage{
 hop_viruses

--- a/man/onion_bacterial_blight.Rd
+++ b/man/onion_bacterial_blight.Rd
@@ -16,7 +16,7 @@
 Roumagnac P, Pruvost O, Chiroleu F, Hughes G. 2004. Spatial and
     temporal analyses of bacterial blight of onion caused by Xanthomonas
     axonopodis pv. allii. Phytopathology 94, 138–146.
-    \href{http://dx.doi.org/10.1094/PHYTO.2004.94.2.138}{doi:10.1094/PHYTO.2004.94.2.138}
+    \href{https://doi.org/10.1094/PHYTO.2004.94.2.138}{doi:10.1094/PHYTO.2004.94.2.138}
 }
 \usage{
 onion_bacterial_blight

--- a/man/power_law.Rd
+++ b/man/power_law.Rd
@@ -54,7 +54,7 @@ Taylor LR. 1961. Aggregation, variance and the mean. Nature 189: 732–35.
 
 Hughes G, Madden LV. 1992. Aggregation and incidence of disease. Plant
 Pathology 41 (6): 657–660.
-\href{http://dx.doi.org/10.1111/j.1365-3059.1992.tb02549.x}{doi:10.1111/j.1365-3059.1992.tb02549.x}
+\href{https://doi.org/10.1111/j.1365-3059.1992.tb02549.x}{doi:10.1111/j.1365-3059.1992.tb02549.x}
 
 Madden LV, Hughes G, van den Bosch F. 2007. Spatial aspects of epidemics -
 III: Patterns of plant disease. In: The study of plant disease epidemics,

--- a/man/pyrethrum_ray_blight.Rd
+++ b/man/pyrethrum_ray_blight.Rd
@@ -14,7 +14,7 @@
 Pethybridge SJ, Esker P, Hay F, Wilson C, Nutter FW. 2005.
     Spatiotemporal description of epidemics caused by Phoma ligulicola in
     Tasmanian pyrethrum fields. \emph{Phytopathology} 95, 648–658.
-    \href{http://dx.doi.org/10.1094/PHYTO-95-0648}{doi:10.1094/PHYTO-95-0648}
+    \href{https://doi.org/10.1094/PHYTO-95-0648}{doi:10.1094/PHYTO-95-0648}
 }
 \usage{
 pyrethrum_ray_blight

--- a/man/sadie.Rd
+++ b/man/sadie.Rd
@@ -87,14 +87,14 @@ sadie(my_df)
 }
 \references{
 Perry JN. 1995. Spatial analysis by distance indices. Journal of Animal
-Ecology 64, 303–314. \href{http://dx.doi.org/10.2307/5892}{doi:10.2307/5892}
+Ecology 64, 303–314. \href{https://doi.org/10.2307/5892}{doi:10.2307/5892}
 
 Perry JN, Winder L, Holland JM, Alston RD. 1999. Red–blue plots for detecting
 clusters in count data. Ecology Letters 2, 106–113.
-\href{http://dx.doi.org/10.1046/j.1461-0248.1999.22057.x}{doi:10.1046/j.1461-0248.1999.22057.x}
+\href{https://doi.org/10.1046/j.1461-0248.1999.22057.x}{doi:10.1046/j.1461-0248.1999.22057.x}
 
 Li B, Madden LV, Xu X. 2012. Spatial analysis by distance indices: an
 alternative local clustering index for studying spatial patterns. Methods in
 Ecology and Evolution 3, 368–377.
-\href{http://dx.doi.org/10.1111/j.2041-210X.2011.00165.x}{doi:10.1111/j.2041-210X.2011.00165.x}
+\href{https://doi.org/10.1111/j.2041-210X.2011.00165.x}{doi:10.1111/j.2041-210X.2011.00165.x}
 }

--- a/man/simulated_epidemics.Rd
+++ b/man/simulated_epidemics.Rd
@@ -17,7 +17,7 @@
 \source{
 Xu XM, Madden LV. 2004. Use of SADIE statistics to study spatial
   dynamics of plant disease epidemics. Plant Pathology 53, 38–49.
-  \href{http://dx.doi.org/10.1111/j.1365-3059.2004.00949.x}{doi:10.1111/j.1365-3059.2004.00949.x}
+  \href{https://doi.org/10.1111/j.1365-3059.2004.00949.x}{doi:10.1111/j.1365-3059.2004.00949.x}
 }
 \usage{
 simulated_epidemics

--- a/man/tomato_tswv.Rd
+++ b/man/tomato_tswv.Rd
@@ -32,7 +32,7 @@
 \source{
 Cochran WG. 1936. The statistical analysis of field counts of
     diseased plants. Supplement to the Journal of the Royal Statistical
-    Society 3, 49–67. \href{http://dx.doi.org/10.2307/2983677}{doi:10.2307/2983677}
+    Society 3, 49–67. \href{https://doi.org/10.2307/2983677}{doi:10.2307/2983677}
 
 Bald JG. 1937. Investigations on "spotted wilt" of tomatoes. III.
     Infection in field plots. Bulletin 106. Melbourne, Australia: Council for


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

Although there is no urgent need to do anything, I'd hereby like to suggest to follow the new recommendation and update all static DOI links in the comments and docu.

Cheers!