### PR TITLE
Fix bug in indices.R along with Warning and Notes when checking package for CRAN

### DIFF
--- a/R/epiphy.R
+++ b/R/epiphy.R
@@ -1,7 +1,7 @@
 #------------------------------------------------------------------------------#
-#' \code{epiphy}: An R package to analyze plant disease epidemics.
+#' \CRANpkg{epiphy}: An R package to analyze plant disease epidemics.
 #'
-#' \strong{epiphy} makes it easy to analyze plant disease epidemics. It provides
+#' \CRANpkg{epiphy} makes it easy to analyze plant disease epidemics. It provides
 #' a common framework for plant disease intensity data recorded over time and/or
 #' space. Implemented statistical methods are currently mainly focused on
 #' spatial pattern analysis (e.g., aggregation indices, Taylor and binary power
@@ -11,7 +11,7 @@
 #'
 #' @author
 #'
-#' \strong{Maintainer:} Christophe Gigot <ch.gigot@gmail.com>
+#' \strong{Maintainer:} Christophe Gigot \email{ch.gigot@@gmail.com}
 #'
 #' @seealso
 #'

--- a/R/indices.R
+++ b/R/indices.R
@@ -141,7 +141,7 @@ fisher.default <- function(x, flavor = c("count", "incidence"), n = NULL, ...) {
     call <- match.call() # TODO: Not yet used.
     stopifnot(is.numeric(x))
     flavor <- match.arg(flavor)
-    if (!is.null(n) && !is.na(n)) {
+    if (!is.null(n) && !any(is.na(n))) {
         # Force "incidence" flavor if n is provided.
         flavor <- "incidence"
     }
@@ -154,12 +154,14 @@ fisher.default <- function(x, flavor = c("count", "incidence"), n = NULL, ...) {
             res <- v / m
         },
         "incidence" = {
-            stopifnot(!is.null(n) && !is.na(n))
+            stopifnot(!is.null(n) && !any(is.na(n)))
             n <- unique(n)
-            if (length(n) != 1) stop(paste0("Current implementation only deals ",
-                                            "with equal size sampling units."))
-            if (!(n > 1)) stop(paste0("The number of individuals per sampling ",
-                                      " unit ('n') must be > 1."))
+            if (length(n) != 1) stop("Current implementation only deals ",
+                                       "with equal size sampling units.",
+                                     call. = FALSE)
+            if (!(n > 1)) stop("The number of individuals per sampling ",
+                                " unit ('n') must be > 1.",
+                               call. = FALSE)
             stopifnot(all(x <= n))
             m <- mean(x / n)
             v <- var(x / n)
@@ -239,7 +241,7 @@ morisita.default <- function(x, flavor = c("count", "incidence"), n = NULL, ...)
     call <- match.call() # TODO: Not yet used.
     stopifnot(is.numeric(x))
     flavor <- match.arg(flavor)
-    if (!is.null(n) && !is.na(n)) {
+    if (!is.null(n) && !any(is.na(n))) {
         # Force "incidence" flavor if n is provided.
         flavor <- "incidence"
     }
@@ -247,17 +249,19 @@ morisita.default <- function(x, flavor = c("count", "incidence"), n = NULL, ...)
     N <- length(x) # Number of sampling units.
     tot <- sum(x)  # Total number of individuals over all the sampling units.
     res <- N * sum(x * (x - 1)) / (tot * (tot - 1))
-    switch (flavor,
+    switch(flavor,
             "count" = {
                 # Do no more calculation.
             },
             "incidence" = {
-                stopifnot(!is.null(n) && !is.na(n))
+                stopifnot(!is.null(n) && !any(is.na(n)))
                 n <- unique(n)
-                if (length(n) != 1) stop(paste0("Current implementation only deals ",
-                                                "with equal size sampling units."))
-                if (!(n > 1)) stop(paste0("The number of individuals per sampling ",
-                                          " unit ('n') must be > 1."))
+                if (length(n) != 1) stop("Current implementation only deals ",
+                                         "with equal size sampling units.",
+                                         call. = FALSE)
+                if (!(n > 1)) stop("The number of individuals per sampling ",
+                                   " unit ('n') must be > 1.",
+                                   call. = FALSE)
                 stopifnot(all(x <= n))
                 res <- res * (n - 1/N) / (n - 1)
             }
@@ -414,7 +418,8 @@ z.test.default <- function(x, ...) {
     #          call. = FALSE)
     # }
     # snse::z.test(x, ...)
-    stop("No method implemented for this kind of data.")
+    stop("No method implemented for this kind of data.",
+         call. = FALSE)
 }
 
 #------------------------------------------------------------------------------#
@@ -530,7 +535,8 @@ calpha.test.fisher <- function(x, ...) {
     N     <- x[["N"]]
     switch (x[["flavor"]],
             "count" = {
-                stop("No calpha.test for count data.")
+                stop("No calpha.test for count data.",
+                     call. = FALSE)
             },
             "incidence" = {
                 n <- x[["n"]]
@@ -552,8 +558,3 @@ calpha.test.fisher <- function(x, ...) {
     ), class = "htest")
 
 }
-
-
-
-
-

--- a/R/intensity-classes.R
+++ b/R/intensity-classes.R
@@ -208,7 +208,8 @@ init_intensity <- function(data, mapping, keep_only_std, type) {
         mapping <- mapping_(paste0(data_std_names, "=", data_std_names))
         # checkings!!!
     } else {
-        if (class(mapping) != "mapping") stop("'mapping' must be a mapping object.")
+        if (isFALSE(inherits(mapping, class(mapping)))) stop("'mapping' must be a mapping object.",
+                                                                call. = FALSE)
         names_mapping <- names(mapping) ## Redondant avec plus bas
         if (!all(i_std <- names_mapping %in% unlist(std_names)) && keep_only_std) { # TODO: What? keep_only_std here?
             #warning("Dropping unrelevant names in mapping.") # NOT CLEAR
@@ -530,7 +531,7 @@ summary.intensity <- function(object, ...) summary(object$data)
 #' @export
 #------------------------------------------------------------------------------#
 as.data.frame.intensity <- function(x, row.names = NULL, optional = FALSE, ...,
-                                    stringsAsFactors = default.stringsAsFactors()) {
+                                    stringsAsFactors = FALSE) {
     # To keep the standard behavior of as.data.frame(), we need to coerce
     # the input data frame to a "simple" list.
     as.data.frame(as.list(x$data), row.names = row.names, optional = optional,
@@ -1035,7 +1036,3 @@ plot.intensity <- function(x, y, ..., type = c("spatial", "temporal", "all"),
     invisible(NULL)
 
 }
-
-
-
-


### PR DESCRIPTION
The current check errors when `n` is a vector, this fix just adds `any()` to the check to see if any values for `n` are `NA` in the vector.

It also cleans up the `stop()` function. The use of `paste0()` is redundant for the message returned to users, and added `call. = FALSE` for a cleaner stop message when a `stop()` is encountered.

The package passes checks with 1 Warning (deprecated fn `default.stringsAsFactors`) and one Note